### PR TITLE
Display duration with tabular digits

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -504,7 +504,7 @@ const Counter = () => {
 
   return (
     <div>
-      <time dateTime={`PT${(tenthSeconds / 10).toFixed(1)}S`}>
+      <time class="tabular-nums" dateTime={`PT${(tenthSeconds / 10).toFixed(1)}S`}>
         {(tenthSeconds / 10).toFixed(1)}s
       </time>
     </div>


### PR DESCRIPTION
I was playing around with this, and noticed the prediction durations jumping around a bit as they counted up. This PR styles this with [tabular figures](https://www.fonts.com/content/learning/fontology/level-3/numbers/proportional-vs-tabular-figures), which should make everything look more even updating. 

This PR also updates the markup to represent the duration with a [`<time>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time).