### PR TITLE
Fix flickering link image

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -286,7 +286,7 @@ export default function Home() {
                     <div className="mt-6 flex">
                       {model.links != null &&
                         model.links.map((link) => (
-                          <a key={uuidv4()} href={link.url}>
+                          <a key={`${model.id}-${link.url}`} href={link.url}>
                             <img
                               src={`/${link.name}.png`}
                               alt={link.name}


### PR DESCRIPTION
I noticed that the links to Replicate and OpenAI flicker when updating predictions as they load. This seems to be caused by their key being randomly generated.

https://github.com/replicate/zoo/assets/7659/b2df635f-4b01-479e-99de-414a0e3ea42c

This PR sets that to a value that should stay consistent and prevent re-rendering.
