### PR TITLE
remove flavors from random prompts

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -191,7 +191,7 @@ export default function Home() {
 
   useEffect(() => {
     const storedModels = localStorage.getItem("models");
-    const prompt = promptmaker();
+    const prompt = promptmaker({ flavors: null });
     setPrompt(prompt);
 
     if (storedModels && checkOrder(JSON.parse(storedModels), MODELS)) {


### PR DESCRIPTION
The "flavors" are random descriptors at the end of the prompt. Maybe too random.

Before:

```
{medium} of {subject} {movement} by {artist}, {flavors}
```

After:

```
{medium} of {subject} {movement} by {artist}
```