### PR TITLE
modularize the database client

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -1,0 +1,7 @@
+import { createClient } from "@supabase/supabase-js";
+
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseKey = process.env.SUPABASE_KEY;
+const db = createClient(supabaseUrl, supabaseKey);
+
+module.exports = db;

--- a/lib/upsertPrediction.js
+++ b/lib/upsertPrediction.js
@@ -1,7 +1,4 @@
-import { createClient } from "@supabase/supabase-js";
-const supabaseUrl = process.env.SUPABASE_URL;
-const supabaseKey = process.env.SUPABASE_KEY;
-const supabase = createClient(supabaseUrl, supabaseKey);
+import db from "./db";
 
 export default async function upsertPrediction(prediction) {
   const predictionObject = {
@@ -21,7 +18,7 @@ export default async function upsertPrediction(prediction) {
     submission_id: prediction.submission_id,
   };
 
-  const { data, error } = await supabase
+  const { data, error } = await db
     .from("predictions")
     .upsert([predictionObject], { onConflict: "id" });
 
@@ -44,7 +41,7 @@ async function uploadImageFromUrl(url, filename) {
   const response = await fetch(url);
   const blob = await response.blob();
 
-  const { data, error } = await supabase.storage
+  const { data, error } = await db.storage
     .from("images")
     .upload(`public/${filename}.png`, blob, {
       cacheControl: "3600",

--- a/pages/api/predictions/[id].js
+++ b/pages/api/predictions/[id].js
@@ -1,8 +1,5 @@
 import Replicate from "replicate";
-import { createClient } from "@supabase/supabase-js";
-const supabaseUrl = process.env.SUPABASE_URL;
-const supabaseKey = process.env.SUPABASE_KEY;
-const supabase = createClient(supabaseUrl, supabaseKey);
+import db from "../../../lib/db";
 
 const replicate = new Replicate({
   auth: process.env.REPLICATE_API_TOKEN,
@@ -13,7 +10,7 @@ export default async function handler(req, res) {
     const prediction = await replicate.predictions.get(req.query.id);
     res.end(JSON.stringify(prediction));
   } else if (req.method === "PUT") {
-    const { data, error } = await supabase
+    const { data, error } = await db
       .from("predictions")
       .update({ submission_id: req.body.submission_id })
       .eq("id", req.query.id);

--- a/pages/api/submissions/[id].js
+++ b/pages/api/submissions/[id].js
@@ -1,11 +1,7 @@
-import { createClient } from "@supabase/supabase-js";
-
-const supabaseUrl = process.env.SUPABASE_URL;
-const supabaseKey = process.env.SUPABASE_KEY;
-const supabase = createClient(supabaseUrl, supabaseKey);
+import db from "../../../lib/db";
 
 export default async function handler(req, res) {
-  const { data, error } = await supabase
+  const { data, error } = await db
     .from("predictions")
     .select()
     .eq("submission_id", req.query.id)

--- a/pages/api/users/[anon_id].js
+++ b/pages/api/users/[anon_id].js
@@ -1,11 +1,7 @@
-import { createClient } from "@supabase/supabase-js";
-
-const supabaseUrl = process.env.SUPABASE_URL;
-const supabaseKey = process.env.SUPABASE_KEY;
-const supabase = createClient(supabaseUrl, supabaseKey);
+import db from "../../../lib/db";
 
 export default async function handler(req, res) {
-  const { data, error } = await supabase
+  const { data, error } = await db
     .from("predictions")
     .select()
     .eq("anon_id", req.query.anon_id)


### PR DESCRIPTION
This PR moves the Supabase client setup to a DRY, reusable module.

This is a stepping stone to making the database optional in the development environment.