### PR TITLE
remove @next/font

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "@headlessui/react": "^1.7.14",
         "@heroicons/react": "^2.0.18",
-        "@next/font": "13.0.7",
         "@prisma/client": "^4.14.0",
         "@supabase/supabase-js": "^2.21.0",
         "@vercel/analytics": "^1.0.1",
@@ -167,11 +166,6 @@
       "dependencies": {
         "glob": "7.1.7"
       }
-    },
-    "node_modules/@next/font": {
-      "version": "13.0.7",
-      "resolved": "https://registry.npmjs.org/@next/font/-/font-13.0.7.tgz",
-      "integrity": "sha512-39SzuoMI6jbrIzPs3KtXdKX03OrVp6Y7kRHcoVmOg69spiBzruPJ5x5DQSfN+OXqznbvVBNZBXnmdnSqs3qXiA=="
     },
     "node_modules/@next/swc-darwin-arm64": {
       "version": "13.4.2",
@@ -4480,11 +4474,6 @@
       "requires": {
         "glob": "7.1.7"
       }
-    },
-    "@next/font": {
-      "version": "13.0.7",
-      "resolved": "https://registry.npmjs.org/@next/font/-/font-13.0.7.tgz",
-      "integrity": "sha512-39SzuoMI6jbrIzPs3KtXdKX03OrVp6Y7kRHcoVmOg69spiBzruPJ5x5DQSfN+OXqznbvVBNZBXnmdnSqs3qXiA=="
     },
     "@next/swc-darwin-arm64": {
       "version": "13.4.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   "dependencies": {
     "@headlessui/react": "^1.7.14",
     "@heroicons/react": "^2.0.18",
-    "@next/font": "13.0.7",
     "@prisma/client": "^4.14.0",
     "@supabase/supabase-js": "^2.21.0",
     "@vercel/analytics": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -94,11 +94,6 @@
   dependencies:
     "glob" "7.1.7"
 
-"@next/font@13.0.7":
-  "integrity" "sha512-39SzuoMI6jbrIzPs3KtXdKX03OrVp6Y7kRHcoVmOg69spiBzruPJ5x5DQSfN+OXqznbvVBNZBXnmdnSqs3qXiA=="
-  "resolved" "https://registry.npmjs.org/@next/font/-/font-13.0.7.tgz"
-  "version" "13.0.7"
-
 "@next/swc-darwin-arm64@13.4.2":
   "integrity" "sha512-6BBlqGu3ewgJflv9iLCwO1v1hqlecaIH2AotpKfVUEzUxuuDNJQZ2a4KLb4MBl8T9/vca1YuWhSqtbF6ZuUJJw=="
   "resolved" "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.2.tgz"


### PR DESCRIPTION
Resolves this:

> Your project has `@next/font` installed as a dependency, please use the built-in `next/font` instead. The `@next/font` package will be removed in Next.js 14. You can migrate by running `npx @next/codemod@latest built-in-next-font .`. Read more: https://nextjs.org/docs/messages/built-in-next-font

Looks like next/font is not actually being used anyway.