### PR TITLE
Correctly show controlnet generations on load

### DIFF
--- a/components/controlnet-prediction.js
+++ b/components/controlnet-prediction.js
@@ -27,7 +27,7 @@ export default function ControlnetPrediction({ prediction }) {
     let response = await fetch(predictionUrl);
 
     if (prediction.output) {
-      if (response.status != 200) {
+      if (response.status == 200) {
         setUrl(predictionUrl);
         setAnnotatedUrl(predictionAnnotationUrl);
         return url;


### PR DESCRIPTION
If the response returns correctly, use the supabase bucket rather than Replicate.
The Logic was the wrong way round – a 200 response was deferring to Replicate.