### PR TITLE
Use Replicate deployments

### DIFF
--- a/lib/models.js
+++ b/lib/models.js
@@ -14,11 +14,14 @@ const MODELS = [
   },
   {
     id: 1,
-    owner: "stability-ai",
-    name: "stable-diffusion 2.1",
-    version: "db21e45d3f7023abc2a46ee38a23973f6dce16bb082a930b0c49861f96d1e5bf",
+    owner: "Stability AI",
+    name: "Stable Diffusion 2.1",
     checked: true,
     source: "replicate",
+    deployment: {
+      owner: "replicate",
+      name: "zoo-stable-diffusion-2x",
+    },
     url: "https://replicate.com/stability-ai/stable-diffusion?utm_source=project&utm_campaign=zoo",
     description:
       "A latent text-to-image diffusion model capable of generating photo-realistic images given any text input",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "react-dom": "18.2.0",
         "react-drag-drop-files": "^2.3.10",
         "react-tooltip": "^5.13.0",
-        "replicate": "^0.6.0",
+        "replicate": "github:replicate/replicate-javascript#deployments",
         "slugify": "^1.6.6",
         "uuid": "^9.0.0"
       },
@@ -1175,16 +1175,6 @@
       "integrity": "sha512-32+ub6kkdhhWick/UjvEwRchgoetXqTK14INLqbGm5U2TzBkBNF3nQtLYm8ovxSkQWArjEQvftCKryjZaATu3w==",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/axios": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.4.tgz",
-      "integrity": "sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==",
-      "dependencies": {
-        "follow-redirects": "^1.15.0",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -3910,11 +3900,6 @@
         "react-is": "^16.13.1"
       }
     },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
-    },
     "node_modules/punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -4062,12 +4047,9 @@
       }
     },
     "node_modules/replicate": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/replicate/-/replicate-0.6.0.tgz",
-      "integrity": "sha512-183GYpYu/lAvktQlMs6BLFDN9jHuQEZLjN0AapN1QvMvwv6TGpowl07afQFqZretpQdFHpIxEkOtQ+ZREWhUxQ==",
-      "dependencies": {
-        "axios": "^1.3.4"
-      }
+      "version": "0.12.1",
+      "resolved": "git+ssh://git@github.com/replicate/replicate-javascript.git#632321066a37ef00413bda29b004e02ade31197d",
+      "license": "Apache-2.0"
     },
     "node_modules/resolve": {
       "version": "1.22.1",
@@ -5696,16 +5678,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.3.tgz",
       "integrity": "sha512-32+ub6kkdhhWick/UjvEwRchgoetXqTK14INLqbGm5U2TzBkBNF3nQtLYm8ovxSkQWArjEQvftCKryjZaATu3w=="
-    },
-    "axios": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.4.tgz",
-      "integrity": "sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==",
-      "requires": {
-        "follow-redirects": "^1.15.0",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
     },
     "axobject-query": {
       "version": "2.2.0",
@@ -7591,11 +7563,6 @@
         "react-is": "^16.13.1"
       }
     },
-    "proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
-    },
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -7691,12 +7658,8 @@
       "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg=="
     },
     "replicate": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/replicate/-/replicate-0.6.0.tgz",
-      "integrity": "sha512-183GYpYu/lAvktQlMs6BLFDN9jHuQEZLjN0AapN1QvMvwv6TGpowl07afQFqZretpQdFHpIxEkOtQ+ZREWhUxQ==",
-      "requires": {
-        "axios": "^1.3.4"
-      }
+      "version": "git+ssh://git@github.com/replicate/replicate-javascript.git#632321066a37ef00413bda29b004e02ade31197d",
+      "from": "replicate@github:replicate/replicate-javascript#deployments"
     },
     "resolve": {
       "version": "1.22.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "react-dom": "18.2.0",
     "react-drag-drop-files": "^2.3.10",
     "react-tooltip": "^5.13.0",
-    "replicate": "^0.6.0",
+    "replicate": "github:replicate/replicate-javascript#deployments",
     "slugify": "^1.6.6",
     "uuid": "^9.0.0"
   },

--- a/pages/index.js
+++ b/pages/index.js
@@ -132,6 +132,7 @@ export default function Home({ baseUrl, submissionPredictions }) {
       body: JSON.stringify({
         prompt: prompt,
         version: model.version,
+        deployment: model.deployment,
         source: model.source,
         model: model.name,
         anon_id: anonId,

--- a/yarn.lock
+++ b/yarn.lock
@@ -662,15 +662,6 @@
   dependencies:
     "follow-redirects" "^1.14.8"
 
-"axios@^1.3.4":
-  "integrity" "sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ=="
-  "resolved" "https://registry.npmjs.org/axios/-/axios-1.3.4.tgz"
-  "version" "1.3.4"
-  dependencies:
-    "follow-redirects" "^1.15.0"
-    "form-data" "^4.0.0"
-    "proxy-from-env" "^1.1.0"
-
 "axobject-query@^2.2.0":
   "integrity" "sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA=="
   "resolved" "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz"
@@ -1430,7 +1421,7 @@
   "resolved" "https://registry.npmjs.org/flatted/-/flatted-3.2.6.tgz"
   "version" "3.2.6"
 
-"follow-redirects@^1.14.8", "follow-redirects@^1.15.0":
+"follow-redirects@^1.14.8":
   "integrity" "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
   "resolved" "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz"
   "version" "1.15.2"
@@ -2374,11 +2365,6 @@
     "object-assign" "^4.1.1"
     "react-is" "^16.13.1"
 
-"proxy-from-env@^1.1.0":
-  "integrity" "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
-  "resolved" "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz"
-  "version" "1.1.0"
-
 "punycode@^2.1.0":
   "integrity" "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
   "resolved" "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz"
@@ -2463,12 +2449,9 @@
   "resolved" "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz"
   "version" "3.2.0"
 
-"replicate@^0.6.0":
-  "integrity" "sha512-183GYpYu/lAvktQlMs6BLFDN9jHuQEZLjN0AapN1QvMvwv6TGpowl07afQFqZretpQdFHpIxEkOtQ+ZREWhUxQ=="
-  "resolved" "https://registry.npmjs.org/replicate/-/replicate-0.6.0.tgz"
-  "version" "0.6.0"
-  dependencies:
-    "axios" "^1.3.4"
+"replicate@github:replicate/replicate-javascript#deployments":
+  "resolved" "git+ssh://git@github.com/replicate/replicate-javascript.git#632321066a37ef00413bda29b004e02ade31197d"
+  "version" "0.12.1"
 
 "resolve-from@^4.0.0":
   "integrity" "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="


### PR DESCRIPTION
This PR updates the model metadata and prediction APIs so we can run API calls through Replicate's nascent Deployments™ feature. This will give us the flexibility to change the underlying model versions and hardware without making code changes.

@replicate/dx 