### PR TITLE
Add Supabase link in footer

### DIFF
--- a/components/footer.js
+++ b/components/footer.js
@@ -67,7 +67,7 @@ export default function Footer() {
             unoptimized={true}
           />
         </Link>
-        <Link className={linkStyles} href="https://github.com/replicate/zoo">
+        <Link className={linkStyles} href="https://supabase.com">
           <Image
             src="/logomarks/supabase.svg"
             data-tooltip-id="supabase-tooltip"


### PR DESCRIPTION
Supabase link in footer was pointing to this repo instead of Supabase's website.

This change makes the link point to https://supabase.com

<img width="534" alt="Captura de pantalla 2023-10-01 a las 16 10 48" src="https://github.com/replicate/zoo/assets/4226553/8864db68-6694-47bd-98ca-30b8e18b1590">
