### PR TITLE
disable dall-e by default

### DIFF
--- a/lib/models.js
+++ b/lib/models.js
@@ -126,9 +126,9 @@ const MODELS = [
   {
     id: 6,
     owner: "OpenAI",
-    name: "DALL-E",
+    name: "DALL-E 2",
     version: "dall-e",
-    checked: true,
+    checked: false,
     default_params: {
       n: 1,
       size: "512x512",


### PR DESCRIPTION
This disables the DALL-E 2 model by default, to reduce OpenAI costs. Users can still switch it on and use it.