### PR TITLE
Only save predictions on completion

### DIFF
--- a/pages/api/predictions/index.js
+++ b/pages/api/predictions/index.js
@@ -56,7 +56,7 @@ export default async function handler(req, res) {
       },
       version: modelObject.version,
       webhook: `${WEBHOOK_HOST}/api/replicate-webhook?${searchParams}`,
-      webhook_events_filter: ["start", "completed"],
+      webhook_events_filter: ["completed"],
     });
 
     const headers = {


### PR DESCRIPTION
We now only store the prediction if it succeeds/fails. This reduces the amount of bandwidth we consume in the application when polling as there's nothing in the db we only return a placeholder.

As far as I can tell the only user visible result this will have is that predictions will not appear in the user list until they have completed.