### PR TITLE
Experiment with in-memory ephemeralCache

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -2,12 +2,15 @@ import { NextRequest, NextResponse } from 'next/server';
 import { Ratelimit } from '@upstash/ratelimit';
 import { kv } from '@vercel/kv';
 
+const ephemeralCache = new Map();
+
 const ratelimit = new Ratelimit({
   redis: kv,
   // 20 requests from the same IP within a 10 second sliding window
   limiter: Ratelimit.slidingWindow(20, '10s'),
   prefix: `v2/zoo/ratelimit/${process.env.VERCEL_ENV ?? 'local'}`,
   timeout: 500,
+  ephemeralCache,
 });
 
 // Rate limit the /api/predictions/[id] endpoint


### PR DESCRIPTION
Should reduce the load on the redis key-value store for the rate limiting. https://github.com/upstash/ratelimit?tab=readme-ov-file#ephemeral-cache